### PR TITLE
Fix installation via pip for anodi v0.0.2.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include *.rst
+recursive-include reqs *.txt

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
     description='A decorator-based backport of PEP-3107 function annotations to Python 2.7, and related tools.',
     long_description=open('README.rst').read(),
 
+    include_package_data=True,
     install_requires=requirements.get('install', None),
     tests_require=requirements.get('extras', {}).get('tests', None),
     extras_require=requirements.get('extras', None),


### PR DESCRIPTION
 Relied on reqs/ folder being present, so included the *.txt files from reqs/ as package data.
